### PR TITLE
Release 0.20.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
         GOOS: [darwin, linux, windows]
         GOARCH: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
          cache: true
 
@@ -26,23 +26,36 @@ jobs:
           export GOARCH=${{ matrix.GOARCH }}
           go build -ldflags "-s -w" -o bin/ github.com/lippkg/lip/cmd/lip
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: bin
 
+  update-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: extract-release-notes
+        uses: ffurrer2/extract-release-notes@v2
+
+      - uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.extract-release-notes.outputs.release_notes }}
+
   upload-to-release:
     needs: 
       - build
+      - update-release-notes
     runs-on: ubuntu-latest
     strategy:
       matrix:
         GOOS: [darwin, linux, windows]
         GOARCH: [amd64, arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support Go module URL as asset URL.
+
 ### Removed
 
 - `source` field in `tooth.json`.
@@ -48,14 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `github.com/blang/semver/v4` for versioning.
 - Refactor most of the code.
 
-### Fixed
-
-- Some bugs.
-
 ### Removed
 
 - Remove `lip autoremove` command.
 - Percentage progress bar.
+
+### Fixed
+
+- Some bugs.
 
 ## [0.17.0] - 2023-12-30
 
@@ -353,15 +357,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Possession field in tooth.json to specify directory to remove when uninstalling a tooth.
 
+### Changed
+
+- Change extension name of tooth files to .tth
+
 ### Fixed
 
 - Fix failing to fetch tooth when the repository does not contain go.mod file.
 - Fix failing to parse tooth file when the tooth is downloaded via GOPROXY.
 - Fix failing to parse tooth when tooth.json is the only file in the tooth.
-
-### Changed
-
-- Change extension name of tooth files to .tth
 
 ## [0.1.0] - 2023-01-17
 
@@ -369,7 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basic functions: cache, install, list, show, tooth init, and uninstall.
 
-[unreleased]: https://github.com/lippkg/lip/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/lippkg/lip/compare/v0.19.0...HEAD
 [0.19.0]: https://github.com/lippkg/lip/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/lippkg/lip/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/lippkg/lip/compare/v0.17.0...v0.18.0
@@ -396,7 +400,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.7.1]: https://github.com/lippkg/lip/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/lippkg/lip/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/lippkg/lip/compare/v0.5.1...v0.6.0
-[0.5.1]: https://github.com/lippkg/lip/compare/v0.4.0...v0.5.1
+[0.5.1]: https://github.com/lippkg/lip/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/lippkg/lip/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/lippkg/lip/compare/v0.3.4...v0.4.0
 [0.3.4]: https://github.com/lippkg/lip/compare/v0.3.3...v0.3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.20.0] - 2024-02-03
 
 ### Added
 
@@ -377,7 +377,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Basic functions: cache, install, list, show, tooth init, and uninstall.
 
-[Unreleased]: https://github.com/lippkg/lip/compare/v0.19.0...HEAD
+[0.20.0]: https://github.com/lippkg/lip/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/lippkg/lip/compare/v0.18.1...v0.19.0
 [0.18.1]: https://github.com/lippkg/lip/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/lippkg/lip/compare/v0.17.0...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support Go module URL as asset URL.
 
+### Changed
+
+- Files downloaded from GitHub mirror are now cached in different paths.
+
 ### Removed
 
 - `source` field in `tooth.json`.

--- a/internal/network/github.go
+++ b/internal/network/github.go
@@ -7,7 +7,7 @@ import (
 
 // GenerateGitHubMirrorURL generates a GitHub mirror URL from a GitHub URL.
 func GenerateGitHubMirrorURL(url *url.URL, gitHubMirrorURL *url.URL) (*url.URL, error) {
-	if !IsGitHubURL(url) {
+	if !IsGitHubDirectDownloadURL(url) {
 		return nil, fmt.Errorf("not a GitHub URL: %v", url)
 	}
 
@@ -20,7 +20,7 @@ func GenerateGitHubMirrorURL(url *url.URL, gitHubMirrorURL *url.URL) (*url.URL, 
 	return mirroredURL, nil
 }
 
-// IsGitHubURL checks if a URL is a GitHub URL.
-func IsGitHubURL(url *url.URL) bool {
-	return url.Host == "github.com"
+// IsGitHubDirectDownloadURL checks if a URL is a GitHub URL that can be directly downloaded.
+func IsGitHubDirectDownloadURL(url *url.URL) bool {
+	return url.Host == "github.com" && (url.Scheme == "http" || url.Scheme == "https")
 }


### PR DESCRIPTION
## What does this PR do?

### Added

- Support Go module URL as asset URL.

### Changed

- Files downloaded from GitHub mirror are now cached in different paths.

### Removed

- `source` field in `tooth.json`.

## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] Your code follows the code style of this repository (see the wiki)
- [ ] You have tested all functions
- [ ] You have not used code without license
- [ ] You have added statement for third-party code
